### PR TITLE
feat: expose mobile hook helper

### DIFF
--- a/src/components/MusicPlayer.tsx
+++ b/src/components/MusicPlayer.tsx
@@ -92,7 +92,9 @@ const YouTubePlayer = ({
       try {
         playerRef.current?.setPlaybackQuality("highres");
         playerRef.current?.setPlaybackQuality("hd1080");
-      } catch {}
+      } catch (error) {
+        console.error("Failed to set playback quality", error);
+      }
     };
 
     const initPlayer = async () => {

--- a/src/hooks/use-mobile.tsx
+++ b/src/hooks/use-mobile.tsx
@@ -35,3 +35,5 @@ export function useMobile() {
     userAgent
   };
 }
+
+export const useIsMobile = () => useMobile().isMobile;


### PR DESCRIPTION
## Summary
- add a dedicated `useIsMobile` helper export so consumers can access the boolean directly
- handle potential playback quality errors in the music player by logging failures, satisfying lint rules

## Testing
- pnpm lint
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d9f7f3b14c833185c89e22a2365c93