### PR TITLE
Improve releases section video layout

### DIFF
--- a/src/components/sections/Releases.tsx
+++ b/src/components/sections/Releases.tsx
@@ -91,13 +91,14 @@ export default function Releases() {
               transition={{ duration: 0.6, delay: 0.3 }}
             >
               <div className="grid grid-cols-1 lg:grid-cols-5 gap-8 items-center">
-                <div className="lg:col-span-3">
-                  <div className="youtube-container shadow-xl shadow-black/30 rounded-lg overflow-hidden">
-                    <iframe 
-                      src={`https://www.youtube.com/embed/${videos[0].id}?si=bS0N7HNSw2W--R0f`} 
+                <div className="lg:col-span-3 flex justify-center">
+                  <div className="relative aspect-video w-full max-w-4xl overflow-hidden rounded-2xl border border-white/10 shadow-2xl shadow-black/30">
+                    <iframe
+                      className="absolute inset-0 h-full w-full"
+                      src={`https://www.youtube.com/embed/${videos[0].id}?si=bS0N7HNSw2W--R0f`}
                       title="YouTube video player"
                       allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                      referrerPolicy="strict-origin-when-cross-origin" 
+                      referrerPolicy="strict-origin-when-cross-origin"
                       allowFullScreen
                     ></iframe>
                   </div>
@@ -141,15 +142,16 @@ export default function Releases() {
               animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 30 }}
               transition={{ duration: 0.6, delay: 0.5 }}
             >
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+              <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-8">
                 {videos.slice(1).map((video, index) => (
-                  <div key={index} className="bg-white/5 backdrop-blur-sm border border-white/10 rounded-xl overflow-hidden hover:border-white/20 transition-colors">
-                    <div className="youtube-container">
-                      <iframe 
-                        src={`https://www.youtube.com/embed/${video.id}?si=bS0N7HNSw2W--R0f`} 
+                  <div key={index} className="flex flex-col bg-white/5 backdrop-blur-sm border border-white/10 rounded-2xl overflow-hidden hover:border-white/20 transition-colors">
+                    <div className="relative aspect-video w-full overflow-hidden">
+                      <iframe
+                        className="absolute inset-0 h-full w-full"
+                        src={`https://www.youtube.com/embed/${video.id}?si=bS0N7HNSw2W--R0f`}
                         title="YouTube video player"
                         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                        referrerPolicy="strict-origin-when-cross-origin" 
+                        referrerPolicy="strict-origin-when-cross-origin"
                         allowFullScreen
                       ></iframe>
                     </div>

--- a/src/hooks/use-video-loader.tsx
+++ b/src/hooks/use-video-loader.tsx
@@ -31,7 +31,7 @@ export function useVideoLoader({
       if (video.paused) {
         video.load();
         const playPromise = video.play();
-        
+
         if (playPromise !== undefined) {
           playPromise.catch(error => {
             // Auto-play was prevented
@@ -48,6 +48,12 @@ export function useVideoLoader({
         }
       }
     };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        loadVideo();
+      }
+    };
     
     // Load video immediately
     loadVideo();
@@ -58,11 +64,7 @@ export function useVideoLoader({
     
     // iOS Safari specific events
     if (isMobileIOS) {
-      document.addEventListener('visibilitychange', () => {
-        if (document.visibilityState === 'visible') {
-          loadVideo();
-        }
-      });
+      document.addEventListener('visibilitychange', handleVisibilityChange);
     }
 
     // Clean up
@@ -70,7 +72,7 @@ export function useVideoLoader({
       video.removeEventListener('loadeddata', loadVideo);
       video.removeEventListener('canplay', loadVideo);
       if (isMobileIOS) {
-        document.removeEventListener('visibilitychange', loadVideo);
+        document.removeEventListener('visibilitychange', handleVisibilityChange);
       }
     };
   }, [isMobile, isMobileIOS, videoSrc]);

--- a/src/index.css
+++ b/src/index.css
@@ -84,25 +84,6 @@ body {
   @apply bg-white/20 rounded-full hover:bg-white/30 transition-colors;
 }
 
-/* Youtube responsive container */
-.youtube-container {
-  position: relative;
-  padding-bottom: 56.25%; /* 16:9 aspect ratio */
-  height: 0;
-  overflow: hidden;
-  max-width: 100%;
-  border-radius: 0.5rem;
-}
-
-.youtube-container iframe {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  border: none;
-}
-
 /* Custom animations */
 @keyframes float {
   0% {


### PR DESCRIPTION
## Summary
- center the featured release video and give it a consistent aspect ratio across viewports
- update the releases grid cards to keep embeds responsive with equal spacing on desktop and mobile
- remove the unused global youtube container styles now that tailwind handles the sizing

## Testing
- pnpm lint *(fails: pre-existing no-empty error in src/components/MusicPlayer.tsx)*
- pnpm build


------
https://chatgpt.com/codex/tasks/task_e_68d9f7f57b68833185ae31994a154099