### PR TITLE
Improve music player controls and playback state

### DIFF
--- a/src/components/MusicPlayer.tsx
+++ b/src/components/MusicPlayer.tsx
@@ -76,11 +76,13 @@ const loadYouTubeAPI = () => {
 const YouTubePlayer = ({
   videoId,
   onEnd,
-  onPlayerReady
+  onPlayerReady,
+  onPlaybackStateChange
 }: {
   videoId: string;
   onEnd: () => void;
   onPlayerReady: (player: YT.Player) => void;
+  onPlaybackStateChange: (state: YT.PlayerState) => void;
 }) => {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const playerRef = useRef<YT.Player | null>(null);
@@ -89,10 +91,9 @@ const YouTubePlayer = ({
     let mounted = true;
 
     const setBestQuality = () => {
-      try {
-        playerRef.current?.setPlaybackQuality("highres");
-        playerRef.current?.setPlaybackQuality("hd1080");
-      } catch {}
+      if (!playerRef.current) return;
+      playerRef.current.setPlaybackQuality("highres");
+      playerRef.current.setPlaybackQuality("hd1080");
     };
 
     const initPlayer = async () => {
@@ -129,6 +130,7 @@ const YouTubePlayer = ({
             ) {
               setBestQuality();
             }
+            onPlaybackStateChange(event.data);
             if (event.data === window.YT.PlayerState.ENDED) {
               onEnd();
             }
@@ -144,7 +146,7 @@ const YouTubePlayer = ({
       playerRef.current?.destroy();
       playerRef.current = null;
     };
-  }, [videoId, onEnd, onPlayerReady]); // ❗ NO dependemos de isPlaying
+  }, [videoId, onEnd, onPlayerReady, onPlaybackStateChange]); // ❗ NO dependemos de isPlaying
 
   return (
     <div className="aspect-video w-full rounded-lg overflow-hidden">
@@ -174,18 +176,27 @@ export default function MusicPlayer() {
   }, [isPlaying, player]);
 
   const previousTrack = useCallback(() => {
+    player?.stopVideo();
     setCurrentTrackIndex((prev) => (prev === 0 ? trackData.length - 1 : prev - 1));
     setIsPlaying(true); // reproducir siguiente al cambiar
-  }, []);
+  }, [player]);
 
   const nextTrack = useCallback(() => {
+    player?.stopVideo();
     setCurrentTrackIndex((prev) => (prev === trackData.length - 1 ? 0 : prev + 1));
     setIsPlaying(true); // reproducir siguiente al cambiar
-  }, []);
+  }, [player]);
 
   const togglePlayer = useCallback(() => {
-    setShowPlayer((prev) => !prev);
-  }, []);
+    setShowPlayer((prev) => {
+      const nextState = !prev;
+      if (prev) {
+        player?.pauseVideo();
+        setIsPlaying(false);
+      }
+      return nextState;
+    });
+  }, [player]);
 
   const handlePlayerReady = useCallback(
     (ytPlayer: YT.Player) => {
@@ -195,6 +206,22 @@ export default function MusicPlayer() {
     },
     [isPlaying]
   );
+
+  const handlePlaybackStateChange = useCallback((state: YT.PlayerState) => {
+    if (state === window.YT.PlayerState.PLAYING) {
+      setIsPlaying(true);
+      return;
+    }
+
+    if (
+      state === window.YT.PlayerState.PAUSED ||
+      state === window.YT.PlayerState.ENDED ||
+      state === window.YT.PlayerState.CUED ||
+      state === window.YT.PlayerState.UNSTARTED
+    ) {
+      setIsPlaying(false);
+    }
+  }, []);
 
   // Si cambias de track y debe reproducir, cuando el nuevo player esté listo, se ejecuta desde handlePlayerReady.
   // Si pausas, ya no recreamos el player por cambio de isPlaying, así que NO se auto-reproduce.
@@ -230,111 +257,114 @@ export default function MusicPlayer() {
           </button>
 
           <div className="max-w-4xl mx-auto">
-            <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 items-start">
+            <div className="flex flex-col lg:flex-row gap-6 lg:gap-10">
               {/* Video */}
-              <div className="col-span-1 lg:col-span-2 h-full">
+              <div className="lg:flex-[2]">
                 <div className="aspect-video w-full">
                   <YouTubePlayer
                     videoId={currentTrack.youtubeId}
                     onEnd={nextTrack}
                     onPlayerReady={handlePlayerReady}
+                    onPlaybackStateChange={handlePlaybackStateChange}
                   />
                 </div>
               </div>
 
               {/* Info + Controles */}
-              <div className="flex flex-col space-y-4 mt-2 lg:mt-0">
-                <div>
-                  <h3 className="font-bold text-lg text-white">{currentTrack.title}</h3>
+              <div className="flex flex-1 flex-col text-white">
+                <div className="space-y-1">
+                  <h3 className="font-bold text-lg">{currentTrack.title}</h3>
                   <p className="text-white/70 text-sm">{currentTrack.artist}</p>
                 </div>
 
-                {/* Controles uniformes y centrados */}
-                <div className="flex justify-center items-center space-x-6 mt-4">
-                  {/* Prev */}
-                  <button
-                    onClick={previousTrack}
-                    className="flex items-center justify-center w-12 h-12 rounded-full bg-white/10 hover:bg-white/20 transition-colors leading-none"
-                    aria-label="Previous track"
-                    type="button"
-                  >
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      viewBox="0 0 24 24"
-                      className="w-5 h-5 block"
-                      stroke="currentColor"
-                      fill="none"
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
+                {/* Controles */}
+                <div className="mt-auto">
+                  <div className="flex items-center justify-center gap-8">
+                    {/* Prev */}
+                    <button
+                      onClick={previousTrack}
+                      className="flex items-center justify-center w-12 h-12 rounded-full bg-white/10 hover:bg-white/20 transition-colors leading-none"
+                      aria-label="Previous track"
+                      type="button"
                     >
-                      <path d="m12 19-7-7 7-7" />
-                      <path d="m19 19-7-7 7-7" />
-                    </svg>
-                  </button>
-
-                  {/* Play / Pause */}
-                  <button
-                    onClick={togglePlayPause}
-                    className="flex items-center justify-center w-14 h-14 rounded-full bg-melody-fuchsia text-white hover:bg-melody-fuchsia/90 transition-colors leading-none"
-                    aria-label={isPlaying ? "Pause" : "Play"}
-                    type="button"
-                  >
-                    {isPlaying ? (
                       <svg
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 24 24"
-                        className="w-6 h-6 block"
+                        className="w-5 h-5 block"
                         stroke="currentColor"
                         fill="none"
                         strokeWidth="2"
                         strokeLinecap="round"
                         strokeLinejoin="round"
                       >
-                        <rect x="6" y="4" width="4" height="16" />
-                        <rect x="14" y="4" width="4" height="16" />
+                        <path d="m12 19-7-7 7-7" />
+                        <path d="m19 19-7-7 7-7" />
                       </svg>
-                    ) : (
+                    </button>
+
+                    {/* Play / Pause */}
+                    <button
+                      onClick={togglePlayPause}
+                      className="flex items-center justify-center w-16 h-16 rounded-full bg-melody-fuchsia text-white hover:bg-melody-fuchsia/90 transition-colors leading-none shadow-lg shadow-melody-fuchsia/30"
+                      aria-label={isPlaying ? "Pause" : "Play"}
+                      type="button"
+                    >
+                      {isPlaying ? (
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          viewBox="0 0 24 24"
+                          className="w-6 h-6 block"
+                          stroke="currentColor"
+                          fill="none"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        >
+                          <rect x="6" y="4" width="4" height="16" />
+                          <rect x="14" y="4" width="4" height="16" />
+                        </svg>
+                      ) : (
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          viewBox="0 0 24 24"
+                          className="w-6 h-6 block"
+                          stroke="currentColor"
+                          fill="none"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        >
+                          <polygon points="5 3 19 12 5 21 5 3" />
+                        </svg>
+                      )}
+                    </button>
+
+                    {/* Next */}
+                    <button
+                      onClick={nextTrack}
+                      className="flex items-center justify-center w-12 h-12 rounded-full bg-white/10 hover:bg-white/20 transition-colors leading-none"
+                      aria-label="Next track"
+                      type="button"
+                    >
                       <svg
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 24 24"
-                        className="w-6 h-6 block"
+                        className="w-5 h-5 block"
                         stroke="currentColor"
                         fill="none"
                         strokeWidth="2"
                         strokeLinecap="round"
                         strokeLinejoin="round"
                       >
-                        <polygon points="5 3 19 12 5 21 5 3" />
+                        <path d="m5 19 7-7-7-7" />
+                        <path d="m12 19 7-7-7-7" />
                       </svg>
-                    )}
-                  </button>
+                    </button>
+                  </div>
 
-                  {/* Next */}
-                  <button
-                    onClick={nextTrack}
-                    className="flex items-center justify-center w-12 h-12 rounded-full bg-white/10 hover:bg-white/20 transition-colors leading-none"
-                    aria-label="Next track"
-                    type="button"
-                  >
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      viewBox="0 0 24 24"
-                      className="w-5 h-5 block"
-                      stroke="currentColor"
-                      fill="none"
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    >
-                      <path d="m5 19 7-7-7-7" />
-                      <path d="m12 19 7-7-7-7" />
-                    </svg>
-                  </button>
-                </div>
-
-                <div className="text-sm text-white/60 mt-4">
-                  <p className="text-center">Track {currentTrackIndex + 1} of {trackData.length}</p>
+                  <div className="text-sm text-white/60 mt-6 text-center">
+                    Track {currentTrackIndex + 1} of {trackData.length}
+                  </div>
                 </div>
               </div>
             </div>

--- a/src/components/sections/Releases.tsx
+++ b/src/components/sections/Releases.tsx
@@ -91,13 +91,14 @@ export default function Releases() {
               transition={{ duration: 0.6, delay: 0.3 }}
             >
               <div className="grid grid-cols-1 lg:grid-cols-5 gap-8 items-center">
-                <div className="lg:col-span-3">
-                  <div className="youtube-container shadow-xl shadow-black/30 rounded-lg overflow-hidden">
-                    <iframe 
-                      src={`https://www.youtube.com/embed/${videos[0].id}?si=bS0N7HNSw2W--R0f`} 
+                <div className="lg:col-span-3 flex justify-center">
+                  <div className="relative aspect-video w-full max-w-4xl overflow-hidden rounded-2xl border border-white/10 shadow-2xl shadow-black/30">
+                    <iframe
+                      className="absolute inset-0 h-full w-full"
+                      src={`https://www.youtube.com/embed/${videos[0].id}?si=bS0N7HNSw2W--R0f`}
                       title="YouTube video player"
                       allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                      referrerPolicy="strict-origin-when-cross-origin" 
+                      referrerPolicy="strict-origin-when-cross-origin"
                       allowFullScreen
                     ></iframe>
                   </div>
@@ -141,15 +142,16 @@ export default function Releases() {
               animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 30 }}
               transition={{ duration: 0.6, delay: 0.5 }}
             >
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+              <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-8">
                 {videos.slice(1).map((video, index) => (
-                  <div key={index} className="bg-white/5 backdrop-blur-sm border border-white/10 rounded-xl overflow-hidden hover:border-white/20 transition-colors">
-                    <div className="youtube-container">
-                      <iframe 
-                        src={`https://www.youtube.com/embed/${video.id}?si=bS0N7HNSw2W--R0f`} 
+                  <div key={index} className="flex flex-col bg-white/5 backdrop-blur-sm border border-white/10 rounded-2xl overflow-hidden hover:border-white/20 transition-colors">
+                    <div className="relative aspect-video w-full overflow-hidden">
+                      <iframe
+                        className="absolute inset-0 h-full w-full"
+                        src={`https://www.youtube.com/embed/${video.id}?si=bS0N7HNSw2W--R0f`}
                         title="YouTube video player"
                         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                        referrerPolicy="strict-origin-when-cross-origin" 
+                        referrerPolicy="strict-origin-when-cross-origin"
                         allowFullScreen
                       ></iframe>
                     </div>

--- a/src/hooks/use-video-loader.tsx
+++ b/src/hooks/use-video-loader.tsx
@@ -31,7 +31,7 @@ export function useVideoLoader({
       if (video.paused) {
         video.load();
         const playPromise = video.play();
-        
+
         if (playPromise !== undefined) {
           playPromise.catch(error => {
             // Auto-play was prevented
@@ -48,6 +48,12 @@ export function useVideoLoader({
         }
       }
     };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        loadVideo();
+      }
+    };
     
     // Load video immediately
     loadVideo();
@@ -58,11 +64,7 @@ export function useVideoLoader({
     
     // iOS Safari specific events
     if (isMobileIOS) {
-      document.addEventListener('visibilitychange', () => {
-        if (document.visibilityState === 'visible') {
-          loadVideo();
-        }
-      });
+      document.addEventListener('visibilitychange', handleVisibilityChange);
     }
 
     // Clean up
@@ -70,7 +72,7 @@ export function useVideoLoader({
       video.removeEventListener('loadeddata', loadVideo);
       video.removeEventListener('canplay', loadVideo);
       if (isMobileIOS) {
-        document.removeEventListener('visibilitychange', loadVideo);
+        document.removeEventListener('visibilitychange', handleVisibilityChange);
       }
     };
   }, [isMobile, isMobileIOS, videoSrc]);

--- a/src/index.css
+++ b/src/index.css
@@ -84,25 +84,6 @@ body {
   @apply bg-white/20 rounded-full hover:bg-white/30 transition-colors;
 }
 
-/* Youtube responsive container */
-.youtube-container {
-  position: relative;
-  padding-bottom: 56.25%; /* 16:9 aspect ratio */
-  height: 0;
-  overflow: hidden;
-  max-width: 100%;
-  border-radius: 0.5rem;
-}
-
-.youtube-container iframe {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  border: none;
-}
-
 /* Custom animations */
 @keyframes float {
   0% {


### PR DESCRIPTION
## Summary
- sync the music player UI with the YouTube iframe state to avoid ghost playback and pause on close
- reposition the player layout so the transport controls stay centered with a larger primary play button
- stop the current video before track changes and reuse the same playback handler for start/stop events

## Testing
- pnpm lint
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d9f7f57b68833185ae31994a154099